### PR TITLE
Refactor: Gather all metadata code in "metadata" module

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@
 
 import driver
 import sys
-import metadata.libtorrent
+import metadata
 
 if __name__ == "__main__":
-    metadata_svc = metadata.libtorrent.LibtorrentMetadataService()
+    metadata_svc = metadata.LibtorrentMetadataService()
     obj = driver.RtorrentLowSpaceDriver(metadata_svc)
     obj.run(sys.argv[1:])

--- a/metadata.py
+++ b/metadata.py
@@ -1,0 +1,11 @@
+import libtorrent
+
+
+class MetadataService:
+    def torrent_info(self, path):
+        raise NotImplementedError("not implemented")
+
+
+class LibtorrentMetadataService(MetadataService):
+    def torrent_info(self, path):
+        return libtorrent.torrent_info(path)

--- a/metadata/__init__.py
+++ b/metadata/__init__.py
@@ -1,4 +1,0 @@
-class MetadataService:
-    def torrent_info(path):
-        raise NotImplementedError("not implemented")
-

--- a/metadata/libtorrent.py
+++ b/metadata/libtorrent.py
@@ -1,7 +1,0 @@
-import libtorrent
-import metadata
-
-class LibtorrentMetadataService(metadata.MetadataService):
-    def torrent_info(self, path):
-        return libtorrent.torrent_info(path)
-


### PR DESCRIPTION
*** Note: I urge you, if acceptable, to accept this PR using a *rebase* instead of a merge; that way we won't pollute git history with a merge of a tiny branch, and the commits will be incorporated linearly into master.

**How it works now:**
In order to parse metadata from .torrent files in the "managed_torrents_directory" one must use a library, and there could be many libraries providing that feature; it makes sense to represent this as an interface, "MetadataService", implemented by a class for each library.

- "MetadataService" class is the interface which has only one method "torrent_info()"
- "LibtorrentMetadaService" class implements the interface by inheriting from the parent class and overriding "torrent_info()" with code that interacts with the "libtorrent" API
- X class does the same for a different torrent library

**The problem:**
In such a situation one could see the appeal in structuring metadata as a package with many modules; however this approach has two problems:
1- That would mean inside that package we have One-Class-Per-Module, this is not recommended as [best practice](https://stackoverflow.com/questions/29914101/python-one-single-module-file-py-for-each-class)
2- Right now there are only two libraries available that do so: [libtorrent-rasterbar](https://github.com/arvidn/libtorrent) and [libTorrent](https://github.com/rakshasa/libtorrent), so the package would only contain two modules. It makes much more sense to gather the code into a single module with the classes, it will be readable and not too big.

**The solution**
Convert the metadata package to a metadata module, updating affected references.
Ps: In the future, if we plan to support magnet URIs, we can just expand the interface with an additional method.