### PR TITLE
Feature: Rclone support

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,21 +1,45 @@
-Rtorrent low space driver.
+## Rtorrent low space driver.
 
 ![test](https://github.com/amoe/rtorrent_low_space_driver/actions/workflows/run-test.yml/badge.svg)
 
-This is designed for the following situation:
+This is a fully automatic torrent rotator, intended to be used in a server that has small space.
 
-1.  You have a bunch of torrents you want to download.
-2.  You have a server with a fast connection but small space.
-3.  You have another SSH-accessible remote host that is slow but has large space.
+We recommend it's usage in the following scenarios:
+- You have a seedbox with a fast connection but small space.
+- You have a RaspberryPi home server, or any other low-power Single Board Computer, with small space. 
 
-It manages and rotates a directory of torrents.  Adds them to rtorrent when they
-can fit.  Syncs completed files to a remote host once they reach the target
-ratio.  Prioritizes the smallest torrents first.  You can use it with unmanaged
-torrents but it won't factor these into space calculations.  Once no more
-torrents will fit, it downloads individual files within torrents and syncs these
-as well.  Only one torrent can be handled in this mode.
+#### What you'll need
+Besides the small-space server you already have, you will need a service with large storage-space that the 
+software can transfer the completed downloads to. This can be either:
+- A cloud storage account.
+- Another server, SSH-accessible server, with large space to store the files.
 
-It requires Python 3.6+ and Rtorrent 0.9.7+.  Older versions will not work.
+Just put the torrent files you want to download in a directory. The rotator will download and synchronize 
+them to the large storage space service.
+
+#### Here's how the magic happens
+
+The script manages and rotates a directory of torrents.  Adds them to rtorrent
+when they can fit.  Syncs completed files to a storage service
+once they reach the target ratio.  Prioritizes the smallest torrents first. You
+can use it alongside unmanaged torrents but it won't factor these into space
+calculations. Once no more torrents will fit, it downloads individual files
+within torrents and syncs these as well.  Only one torrent can be handled in
+this mode.
+
+It will sync the complete torrents to virtually any cloud storage service, thanks
+to the powerful [Rclone](https://rclone.org/) backend.
+If the destination is a remote server, it must be accessible via SSH.
+
+
+### Installation procedure
+
+You will need to have Python 3.6+ and Rtorrent 0.9.7+ installed.  Older versions 
+will not work.
+
+If you want use the cloud sync feature, you must have [Rclone](https://rclone.org/) installed.
+[Don't forget to configure Rclone first!](https://rclone.org/docs/)
+
 
 Your rtorrent will need to be configured for XMLRPC access over SCGI.  To enable
 this, add the following lines to `~/.rtorrent.rc`:
@@ -43,6 +67,8 @@ All paths need to be absolute.  The value for `space_limit` is in bytes.  The
 value for `socket_url` needs to match the value in `.rtorrent.rc`, but with the
 `scgi://` prefix.
 
+If you want to use Rclone, look at the examples in `/templates`.
+
 Run it from cron with a lock.  Every hour is quite appropriate.
 Although the transfer will often take longer, so the lock is essential
 if you don't want to fill up your process table with rsync instances.
@@ -53,10 +79,11 @@ if you don't want to fill up your process table with rsync instances.
 
 The LANG setting is required, otherwise some attempts to format output will
 fail, despite UTF-8 being hardcoded in many places.  This is to be considered a
-bug.  (The failing call is `subprocess.check_call` in
-`sync_completed_path_to_remote`.)
+bug.  (The failing call is `subprocess.check_call` in Rsync's `sync_path`.)
 
 If space on the remote runs out, the rsync process can hang in a repeated retry.
+
+Please run the command with the flag --help to check for other supported options.
 
 Many thanks to Roger Que for the SCGI module, and the authors of
 Pyroscope for a bit of inspiration.

--- a/remotesync.py
+++ b/remotesync.py
@@ -198,7 +198,7 @@ class Rclone(RemoteSyncEngine):
         # User-defined flags replace default ones.
         self.rclone_flags = {
             **self.DEFAULT_FLAGS,
-            **{k.upper(): v for k, v in kwargs if k.startswith('rclone_')}
+            **{k.upper(): v for k, v in kwargs.items() if k.startswith('rclone_')}
         }
         debug('Rclone environment variables: %s' % pformat(self.rclone_flags, compact=True))
 

--- a/remotesync.py
+++ b/remotesync.py
@@ -192,7 +192,7 @@ class Rclone(RemoteSyncEngine):
         # Warn user that he is overriding some default flags.
         flags = set(self.DEFAULT_FLAGS.keys()) & set(kwargs.keys())
         if flags:
-            warning('Flags %s were passed, these might mess up log formatting, thread carefully!' % flags)
+            warning('Flags %s were passed, these might mess up log formatting, tread carefully!' % flags)
 
         # Store all flags that apply to rclone.
         # User-defined flags replace default ones.

--- a/remotesync.py
+++ b/remotesync.py
@@ -19,9 +19,9 @@ def get_service(**kwargs):
         kwargs['rsync_host'] = kwargs.pop('remote_host')
         kwargs['rsync_path'] = kwargs.pop('remote_path')
         return Rsync(**kwargs)
-    elif service == 'rsync':
+    if service == 'rsync':
         return Rsync(**kwargs)
-    elif service == 'rclone':
+    if service == 'rclone':
         return Rclone(**kwargs)
 
 

--- a/templates/template_rclone_rtorrent_low_space_driver.cf
+++ b/templates/template_rclone_rtorrent_low_space_driver.cf
@@ -1,0 +1,12 @@
+# This template in intended to showcase the usage to synchronize to a
+# cloud service using rclone.
+# You should already have a working rclone config, per the instructions on their website.
+[main]
+managed_torrents_directory = /home/amoe/managed_torrents
+space_limit = 3221225472
+required_ratio = 1.0
+socket_url = scgi:///home/amoe/.rtorrent.sock
+remote_sync_service = rclone
+rclone_remote = someremote              #The remote name should be the same as configured with rclone.
+rclone_path = /place/with/space         #Path in the specified remote.
+rclone_config = /some/path/rclone.conf  #optional, if not set, the current user's rclone config file will be used.

--- a/templates/template_rsync_rtorrent_low_space_driver.cf
+++ b/templates/template_rsync_rtorrent_low_space_driver.cf
@@ -1,0 +1,11 @@
+# This template in intended to showcase the usage to synchronize to a
+# remote SSH-accessible server.
+# SSH keys should already be configured for passwordless login.
+[main]
+managed_torrents_directory = /home/amoe/managed_torrents
+space_limit = 3221225472
+required_ratio = 1.0
+socket_url = scgi:///home/amoe/.rtorrent.sock
+remote_sync_service = rsync
+rsync_host = somehost                   #The rsync target host, authentication must be passwordless.
+rsync_path = /place/with/space          #Path in the specified rsync host.


### PR DESCRIPTION
Note: This PR depends on #6 , #7, #8 and #9, please review them first.
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This feature implements rclone support. 
Set the following keys to use it:
- "remote_sync_service=rclone"
- "rclone_remote" and "rclone_path": Use the same name as used in rclone's rclone.conf file and the path in that remote.
- "rclone_someflag": Use any environment variable as described [here](https://rclone.org/docs/#environment-variables) and [here](https://rclone.org/flags/). Use lowercase keys, the software will automatically convert it to uppercase.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I needed to sync to the cloud. Rclone is one of the best options as it supports hundreds of cloud providers.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Main, test and test_config pass in my system python and in Travis-CI.
Haven't tested a full torrent workflow (add, download and remotesync)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
