### PR TITLE
Basic validation of missing mandatory configs.

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -48,10 +48,10 @@ class RtorrentLowSpaceDriver(object):
         self.metadata_service = metadata_service
 
         info("Starting.")
-        self.MANAGED_TORRENTS_DIRECTORY = cfg.get('managed_torrents_directory')
-        self.SPACE_LIMIT = int(cfg.get('space_limit'))
-        self.REQUIRED_RATIO = float(cfg.get('required_ratio'))
-        self.SOCKET_URL = cfg.get('socket_url')
+        self.MANAGED_TORRENTS_DIRECTORY = cfg['managed_torrents_directory']
+        self.SPACE_LIMIT = int(cfg['space_limit'])
+        self.REQUIRED_RATIO = float(cfg['required_ratio'])
+        self.SOCKET_URL = cfg['socket_url']
 
         self.remote_sync_service = remotesync.get_service(**cfg)
 

--- a/driver.py
+++ b/driver.py
@@ -1,4 +1,4 @@
-from logging import debug, info, error, warning
+from logging import debug, info, error, warning, critical
 import os
 import os.path
 from pprint import pformat
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 import time
 import shutil
+import sys
 
 import rtorrent_xmlrpc
 import remotesync
@@ -48,12 +49,15 @@ class RtorrentLowSpaceDriver(object):
         self.metadata_service = metadata_service
 
         info("Starting.")
-        self.MANAGED_TORRENTS_DIRECTORY = cfg['managed_torrents_directory']
-        self.SPACE_LIMIT = int(cfg['space_limit'])
-        self.REQUIRED_RATIO = float(cfg['required_ratio'])
-        self.SOCKET_URL = cfg['socket_url']
-
-        self.remote_sync_service = remotesync.get_service(**cfg)
+        try:
+            self.MANAGED_TORRENTS_DIRECTORY = cfg['managed_torrents_directory']
+            self.SPACE_LIMIT = int(cfg['space_limit'])
+            self.REQUIRED_RATIO = float(cfg['required_ratio'])
+            self.SOCKET_URL = cfg['socket_url']
+            self.remote_sync_service = remotesync.get_service(**cfg)
+        except KeyError as e:
+            critical(f'Missing key {e} from the config file. Exiting!')
+            sys.exit(1)
 
         self.server = rtorrent_xmlrpc.SCGIServerProxy(self.SOCKET_URL)
 

--- a/remotesync.py
+++ b/remotesync.py
@@ -69,11 +69,8 @@ class Rsync(RemoteSyncEngine):
     LOCAL_WAIT_TIME = RECEIVE_SERVER_TIMEOUT * 10
 
     def __init__(self, **kwargs):
-        self.RSYNC_HOST = kwargs.get('rsync_host')
-        self.RSYNC_PATH = kwargs.get('rsync_path')
-
-        assert self.RSYNC_HOST is not None
-        assert self.RSYNC_PATH is not None
+        self.RSYNC_HOST = kwargs['rsync_host']
+        self.RSYNC_PATH = kwargs['rsync_path']
 
     def get_remote_path(self, realpath):
         return os.path.join(self.RSYNC_PATH, os.path.basename(realpath))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Your commit of 65fbd76743ed676e934b0f12d03ae7e7338002e0 seems to be a valid way to assert user input errors. What I'm proposing here is that null checks could be used in this form. Leaving possible `asserts`  for higher-level checks, such as if a directory exists and is accessible, or rclone is installed. Looking forward to your opinion.

Proposal:
If using dicitonary's foo['key'] instead of foo.get('key'), a missing key will raise a KeyError with the key name beside it, treat it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Null misconfig validation that doesnt belong in unit testing, but in the main program.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran main.py using old format, new rsync and new rclone, trying missing keys in each. A KeyError is raised with the named key beside it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
