### PR TITLE
Subprocess logging.

### DIFF
--- a/remotesync.py
+++ b/remotesync.py
@@ -166,7 +166,7 @@ class Rsync(RemoteSyncEngine):
     def rsync_command(self):
         rst = self.RECEIVE_SERVER_TIMEOUT
         return [
-            'rsync', '-aPv', f"--timeout={rst}"
+            'rsync', '-a', '--partial', f"--timeout={rst}"
         ]
 
     def pessimistic_wait(self):

--- a/remotesync.py
+++ b/remotesync.py
@@ -125,10 +125,7 @@ class Rsync(RemoteSyncEngine):
                 # remote path must be quoted, lest it be interpreted wrongly
                 # by the shell on the server side.
                 output = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8').stdout
-
-                # Split all output, remember that rtorrent is returning unicode
-                # strings to us so we need to create unicode strings so that
-                # they can be compared to the list of locally completed files.
+                
                 remote_files = output.rstrip().split("\n")
 
                 return [
@@ -260,10 +257,7 @@ class Rclone(RemoteSyncEngine):
         while True:
             try:
                 output = subprocess.run(cmd, check=True, capture_output=True, encoding='utf8', env=self.env).stdout
-
-                # Split all output, remember that rtorrent is returning unicode
-                # strings to us so we need to create unicode strings so that
-                # they can be compared to the list of locally completed files.
+                
                 remote_files = output.rstrip().split("\n")
                 return remote_files
             except subprocess.CalledProcessError as e:

--- a/remotesync.py
+++ b/remotesync.py
@@ -185,16 +185,18 @@ class Rclone(RemoteSyncEngine):
         # Rclone config flags can be set entirely using environment variables.
         # This is what is done in this implementation.
         # https://rclone.org/docs/#environment-variables
+        _rclone_flags = {k.upper(): v for k, v in kwargs.items() if k.startswith('rclone_')}
+
         # Warn user that he is overriding some default flags.
-        flags = set(self.DEFAULT_FLAGS.keys()) & set(kwargs.keys())
-        if flags:
-            warning('Flags %s were passed, these might mess up log formatting, tread carefully!' % flags)
+        overwrite = set(self.DEFAULT_FLAGS.keys()) & set(_rclone_flags.keys())
+        if overwrite:
+            warning('Flags %s were passed, these might mess up log formatting, tread carefully!' % overwrite)
 
         # Store all flags that apply to rclone.
         # User-defined flags replace default ones.
         self.rclone_flags = {
             **self.DEFAULT_FLAGS,
-            **{k.upper(): v for k, v in kwargs.items() if k.startswith('rclone_')}
+            **_rclone_flags
         }
         debug('Rclone environment variables: %s' % pformat(self.rclone_flags, compact=True))
 

--- a/remotesync.py
+++ b/remotesync.py
@@ -274,7 +274,7 @@ class Rclone(RemoteSyncEngine):
 
     def sync_files_from_filelist(self, realpath, filelist_path):
         remote_path = "%s:%s" \
-                      % (self.RCLONE_REMOTE, pipes.quote(self.get_remote_path(realpath)))
+                      % (self.RCLONE_REMOTE, self.get_remote_path(realpath))
 
         # When realpath is a directory, copyto works exactly as copy command
         cmd = ['rclone', 'copyto', "--files-from=" + filelist_path, realpath, remote_path]

--- a/remotesync.py
+++ b/remotesync.py
@@ -178,9 +178,8 @@ class Rclone(RemoteSyncEngine):
     LOCAL_WAIT_TIME = 300
     DEFAULT_FLAGS = {'RCLONE_STATS': '8h',
                      'RCLONE_STATS_ONE_LINE': 'true',
-                     'RCLONE_LOG_FORMAT': '',
-                     'RCLONE_LOG_LEVEL': 'INFO',
-                     'RCLONE_RETRIES': '1'}
+                     'RCLONE_STATS_LOG_LEVEL': 'NOTICE',
+                     'RCLONE_LOG_FORMAT': ''}
 
     def __init__(self, **kwargs):
         self.RCLONE_REMOTE = kwargs.pop('rclone_remote')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Closes #14 

This implements logging of all `subprocess` calls.

Although this PR correctly handles subprocess output, the behavior implemented in this Pull Request is **NOT the same** behavior that was proposed on #14.

This is because, after some thought, I found that, if the command runs successfully, the user shouldn't be shown the command's generated output.
If the command runs and fails, the user should see the Standard Error.

If the methods succeed, all messages are supressed from the user's view and nothing is logged.
If the methods fail, the error is logged. If running on DEBUG level, the standard error is also logged.

Also implemented in this PR:
- Deactivated verbose mode on `rsync` and on `rclone`.
- Fix Rclone class init bug, it wasn't printing the overridden flags with the 'Tread carefully message', because it wasn't uppercase.
- Removed quotes from rclone copyto command, because it wasn't working in the terminal.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This closes Issue #14.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran test_config, test_driver.
I tested the Full Workflow of a Large Torrent, and of a Small Torrent, using both Rsync and Rclone services. 
It works.
Also tested the errors, they are correctly logged.

The only thing I haven't tested is if a long-running process (hours long) would error out mid-way, if the StdErr would be correctly caught.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
